### PR TITLE
Do not use LFS for storing dataset sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,9 @@ ThisBuild / version := "0.1.0-SNAPSHOT"
 ThisBuild / scalaVersion := "3.2.2"
 
 lazy val akkaV = "2.6.19"
+lazy val akkaHttpV = "10.2.10"
 lazy val alpakkaV = "3.0.4"
+lazy val circeV = "0.14.5"
 lazy val jenaV = "4.7.0"
 lazy val rdf4jV = "4.2.3"
 
@@ -14,6 +16,9 @@ lazy val root = (project in file("."))
     // Scala 3 or not Scala at all
     libraryDependencies ++= Seq(
       "com.google.guava" % "guava" % "31.1-jre",
+      "io.circe" %% "circe-core" % circeV,
+      "io.circe" %% "circe-generic" % circeV,
+      "io.circe" %% "circe-parser" % circeV,
       "org.apache.jena" % "jena-core" % jenaV,
       "org.apache.jena" % "jena-arq" % jenaV,
       "org.apache.jena" % "jena-shacl" % jenaV,
@@ -27,6 +32,8 @@ lazy val root = (project in file("."))
       "com.lightbend.akka" %% "akka-stream-alpakka-file" % alpakkaV,
       "com.typesafe.akka" %% "akka-actor-typed" % akkaV,
       "com.typesafe.akka" %% "akka-stream-typed" % akkaV,
+      "com.typesafe.akka" %% "akka-http" % akkaHttpV,
+      "com.typesafe.akka" %% "akka-http-core" % akkaHttpV,
     ).map(_.cross(CrossVersion.for3Use2_13)),
 
     // Discard module-info.class files

--- a/src/main/scala/util/ReleaseInfoParser.scala
+++ b/src/main/scala/util/ReleaseInfoParser.scala
@@ -1,0 +1,25 @@
+package io.github.riverbench.ci_worker
+package util
+
+import _root_.io.circe.*
+import _root_.io.circe.generic.semiauto.*
+import _root_.io.circe.parser.decode
+
+import java.nio.file.{Files, Path}
+
+object ReleaseInfoParser:
+  case class ReleaseInfo(assets: List[Asset])
+  case class Asset(name: String, browser_download_url: String)
+
+  implicit val relInfoDecoder: Decoder[ReleaseInfo] = deriveDecoder[ReleaseInfo]
+  implicit val assetDecoder: Decoder[Asset] = deriveDecoder[Asset]
+
+  def parse(path: Path): Either[Error, ReleaseInfo] =
+    val json = Files.readString(path)
+    decode[ReleaseInfo](json)
+
+  def getDatasetUrl(path: Path): String =
+    val possibleNames = List("triples.tar.gz", "quads.tar.gz", "graphs.tar.gz")
+    parse(path).toOption.get.assets
+      .filter(asset => possibleNames.contains(asset.name))
+      .head.browser_download_url


### PR DESCRIPTION
Instead, the files will be stored as releases. This will allow for skipping the downloading of the releases from LFS. Instead, the file can be directly streamed over HTTP to the worker.