### PR TITLE
Migrate Akka to Apache Pekko

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
 ThisBuild / version := "0.1.0-SNAPSHOT"
-ThisBuild / scalaVersion := "3.2.2"
+ThisBuild / scalaVersion := "3.3.0"
 
-lazy val akkaV = "2.6.19"
-lazy val akkaHttpV = "10.2.10"
-lazy val alpakkaV = "3.0.4"
+lazy val pekkoV = "1.0.1"
+lazy val pekkoHttpV = "1.0.0"
+lazy val pekkoConnV = "1.0.0"
 lazy val circeV = "0.14.5"
 lazy val jenaV = "4.7.0"
-lazy val rdf4jV = "4.2.3"
+lazy val rdf4jV = "4.3.0"
 
 lazy val root = (project in file("."))
   .settings(
@@ -23,19 +23,15 @@ lazy val root = (project in file("."))
       "org.apache.jena" % "jena-core" % jenaV,
       "org.apache.jena" % "jena-arq" % jenaV,
       "org.apache.jena" % "jena-shacl" % jenaV,
+      "org.apache.pekko" %% "pekko-connectors-file" % pekkoConnV,
+      "org.apache.pekko" %% "pekko-actor-typed" % pekkoV,
+      "org.apache.pekko" %% "pekko-stream-typed" % pekkoV,
+      "org.apache.pekko" %% "pekko-http" % pekkoHttpV,
+      "org.apache.pekko" %% "pekko-http-core" % pekkoHttpV,
       "org.eclipse.rdf4j" % "rdf4j-model" % rdf4jV,
       "org.eclipse.rdf4j" % "rdf4j-rio-turtle" % rdf4jV,
       "org.eclipse.rdf4j" % "rdf4j-rio-trig" % rdf4jV,
     ),
-
-    // Packages available only with Scala 2.13
-    libraryDependencies ++= Seq(
-      "com.lightbend.akka" %% "akka-stream-alpakka-file" % alpakkaV,
-      "com.typesafe.akka" %% "akka-actor-typed" % akkaV,
-      "com.typesafe.akka" %% "akka-stream-typed" % akkaV,
-      "com.typesafe.akka" %% "akka-http" % akkaHttpV,
-      "com.typesafe.akka" %% "akka-http-core" % akkaHttpV,
-    ).map(_.cross(CrossVersion.for3Use2_13)),
 
     // Discard module-info.class files
     // Just Java Things (tm), I guess

--- a/src/main/scala/commands/Command.scala
+++ b/src/main/scala/commands/Command.scala
@@ -1,7 +1,7 @@
 package io.github.riverbench.ci_worker
 package commands
 
-import akka.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.ActorSystem
 
 import scala.concurrent.{ExecutionContext, Future}
 

--- a/src/main/scala/commands/DatasetDocGenCommand.scala
+++ b/src/main/scala/commands/DatasetDocGenCommand.scala
@@ -1,10 +1,10 @@
 package io.github.riverbench.ci_worker
 package commands
 
-import util.{MetadataInfo, MetadataReader, RdfIoUtil, RdfUtil}
 import util.doc.DocBuilder
+import util.{MetadataInfo, MetadataReader, RdfIoUtil, RdfUtil}
 
-import org.apache.jena.rdf.model.{Model, ModelFactory, Property, Resource}
+import org.apache.jena.rdf.model.Property
 import org.apache.jena.riot.RDFDataMgr
 import org.apache.jena.sparql.vocabulary.FOAF
 import org.apache.jena.vocabulary.{RDF, RDFS}

--- a/src/main/scala/commands/NavGenCommand.scala
+++ b/src/main/scala/commands/NavGenCommand.scala
@@ -7,7 +7,6 @@ import util.YamlDocBuilder.*
 import java.lang.module.ModuleDescriptor.Version
 import java.nio.file.{FileSystems, Files, Path}
 import scala.concurrent.Future
-import scala.jdk.CollectionConverters.*
 
 object NavGenCommand extends Command:
   override def name: String = "nav-gen"

--- a/src/main/scala/commands/PackageCommand.scala
+++ b/src/main/scala/commands/PackageCommand.scala
@@ -1,23 +1,22 @@
 package io.github.riverbench.ci_worker
 package commands
 
-import akka.stream.*
-import akka.{Done, NotUsed}
-import akka.stream.scaladsl.*
 import util.*
 import util.io.*
 
-import akka.stream.alpakka.file.TarArchiveMetadata
-import akka.util.ByteString
-import org.apache.jena.query.DatasetFactory
 import org.apache.jena.rdf.model.{ModelFactory, Resource}
 import org.apache.jena.riot.system.ErrorHandlerFactory
-import org.apache.jena.riot.{Lang, RDFDataMgr, RDFParser, RDFWriter}
+import org.apache.jena.riot.{Lang, RDFParser, RDFWriter}
 import org.apache.jena.sparql.core.{DatasetGraph, DatasetGraphFactory}
+import org.apache.pekko.stream.*
+import org.apache.pekko.stream.connectors.file.TarArchiveMetadata
+import org.apache.pekko.stream.scaladsl.*
+import org.apache.pekko.util.ByteString
+import org.apache.pekko.{Done, NotUsed}
 import org.eclipse.rdf4j.model.vocabulary.XSD
 import org.eclipse.rdf4j.rio
 
-import java.io.{ByteArrayInputStream, FileOutputStream, InputStream}
+import java.io.{ByteArrayInputStream, FileOutputStream}
 import java.nio.file.{FileSystems, Path}
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters.*

--- a/src/main/scala/commands/PackageMainCommand.scala
+++ b/src/main/scala/commands/PackageMainCommand.scala
@@ -1,11 +1,11 @@
 package io.github.riverbench.ci_worker
 package commands
 
-import util.{AppConfig, Constants, DatasetCollection, MetadataReader, ProfileCollection, RdfUtil}
+import util.doc.MarkdownUtil
+import util.*
 
-import io.github.riverbench.ci_worker.util.doc.MarkdownUtil
 import org.apache.jena.rdf.model.{Model, Property, RDFNode, Resource}
-import org.apache.jena.riot.{Lang, RDFDataMgr}
+import org.apache.jena.riot.RDFDataMgr
 import org.apache.jena.vocabulary.RDF
 
 import java.io.FileOutputStream

--- a/src/main/scala/commands/PackageSchemaCommand.scala
+++ b/src/main/scala/commands/PackageSchemaCommand.scala
@@ -4,7 +4,7 @@ package commands
 import util.{AppConfig, Constants}
 
 import org.apache.jena.rdf.model.Model
-import org.apache.jena.riot.{Lang, RDFDataMgr, RDFFormat}
+import org.apache.jena.riot.{RDFDataMgr, RDFFormat}
 import org.apache.jena.vocabulary.{OWL, OWL2, RDF}
 
 import java.io.FileOutputStream

--- a/src/main/scala/commands/ParseTestCommand.scala
+++ b/src/main/scala/commands/ParseTestCommand.scala
@@ -1,12 +1,12 @@
 package io.github.riverbench.ci_worker
 package commands
 
-import akka.stream.scaladsl.Source
 import util.Rdf4jUtil
-import org.apache.jena.rdf.model.ModelFactory
-import org.apache.jena.riot.{Lang, RDFParser}
+
 import org.apache.jena.riot.system.ErrorHandlerFactory
+import org.apache.jena.riot.{Lang, RDFParser}
 import org.apache.jena.sparql.graph.GraphFactory
+import org.apache.pekko.stream.scaladsl.Source
 import org.eclipse.rdf4j.rio
 import org.eclipse.rdf4j.rio.RDFFormat
 

--- a/src/main/scala/commands/SchemaDocGenCommand.scala
+++ b/src/main/scala/commands/SchemaDocGenCommand.scala
@@ -4,9 +4,8 @@ package commands
 import util.AppConfig
 
 import org.apache.jena.rdf.model.Model
-import org.apache.jena.riot.{RDFDataMgr, RDFFormat}
+import org.apache.jena.riot.RDFDataMgr
 
-import java.io.FileOutputStream
 import java.nio.file.{FileSystems, Files, Path}
 import scala.collection.mutable
 import scala.concurrent.Future

--- a/src/main/scala/commands/TagDocumentationCommand.scala
+++ b/src/main/scala/commands/TagDocumentationCommand.scala
@@ -3,8 +3,6 @@ package commands
 
 import java.nio.file.{FileSystems, Files, Path}
 import scala.concurrent.Future
-import scala.jdk.CollectionConverters.*
-import scala.util.matching.Regex
 
 object TagDocumentationCommand extends Command:
   def name: String = "tag-docs"

--- a/src/main/scala/commands/ValidateRepoCommand.scala
+++ b/src/main/scala/commands/ValidateRepoCommand.scala
@@ -1,21 +1,20 @@
 package io.github.riverbench.ci_worker
 package commands
 
-import util.{MetadataInfo, MetadataReader, ReleaseInfoParser}
+import util.ReleaseInfoParser.ReleaseInfo
 import util.io.FileHelper
+import util.{MetadataInfo, MetadataReader, ReleaseInfoParser}
 
-import akka.stream.scaladsl.Sink
-import io.github.riverbench.ci_worker.util.ReleaseInfoParser.ReleaseInfo
 import org.apache.commons.io.output.ByteArrayOutputStream
 import org.apache.jena.rdf.model.{Model, ModelFactory}
 import org.apache.jena.riot.RDFDataMgr
 import org.apache.jena.shacl.lib.ShLib
 import org.apache.jena.shacl.{ShaclValidator, Shapes}
+import org.apache.pekko.stream.scaladsl.Sink
 
 import java.nio.file.{FileSystems, Files, Path}
 import scala.collection.mutable
 import scala.concurrent.Future
-import scala.concurrent.duration.Duration
 import scala.jdk.CollectionConverters.*
 
 object ValidateRepoCommand extends Command:

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -2,9 +2,9 @@ package io.github.riverbench.ci_worker
 
 import commands.Command
 
-import akka.actor.typed.ActorSystem
-import akka.actor.typed.scaladsl.Behaviors
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}
 
 import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}

--- a/src/main/scala/util/StatCounter.scala
+++ b/src/main/scala/util/StatCounter.scala
@@ -3,10 +3,7 @@ package util
 
 import com.google.common.hash.{BloomFilter, Funnel, PrimitiveSink}
 import org.apache.jena.datatypes.xsd.XSDDatatype.*
-import org.apache.jena.graph.NodeFactory
-import org.apache.jena.rdf.model.{Model, Resource}
-
-import java.util
+import org.apache.jena.rdf.model.Resource
 
 //noinspection UnstableApiUsage
 object StatCounter:

--- a/src/main/scala/util/StatCounterSuite.scala
+++ b/src/main/scala/util/StatCounterSuite.scala
@@ -3,12 +3,10 @@ package util
 
 import org.apache.jena.datatypes.xsd.XSDDatatype.*
 import org.apache.jena.graph.{Node, Triple}
-import org.apache.jena.query.Dataset
-import org.apache.jena.rdf.model.{Model, Resource}
+import org.apache.jena.rdf.model.Resource
 import org.apache.jena.sparql.core.DatasetGraph
 import org.apache.jena.vocabulary.RDF
 
-import scala.::
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
 

--- a/src/main/scala/util/YamlDocBuilder.scala
+++ b/src/main/scala/util/YamlDocBuilder.scala
@@ -1,8 +1,6 @@
 package io.github.riverbench.ci_worker
 package util
 
-import scala.annotation.tailrec
-
 object YamlDocBuilder:
   sealed trait YamlValue
   case class YamlString(v: String) extends YamlValue

--- a/src/main/scala/util/doc/DocGroupRegistry.scala
+++ b/src/main/scala/util/doc/DocGroupRegistry.scala
@@ -1,7 +1,8 @@
 package io.github.riverbench.ci_worker
 package util.doc
 
-import io.github.riverbench.ci_worker.util.RdfUtil
+import util.RdfUtil
+
 import org.apache.jena.rdf.model.Model
 import org.apache.jena.vocabulary.{RDF, RDFS}
 

--- a/src/main/scala/util/doc/DocProp.scala
+++ b/src/main/scala/util/doc/DocProp.scala
@@ -3,7 +3,7 @@ package util.doc
 
 import util.RdfUtil
 
-import org.apache.jena.rdf.model.{Model, Property, Resource}
+import org.apache.jena.rdf.model.{Model, Resource}
 import org.apache.jena.vocabulary.RDFS
 
 object DocProp:

--- a/src/main/scala/util/doc/DocSection.scala
+++ b/src/main/scala/util/doc/DocSection.scala
@@ -1,7 +1,7 @@
 package io.github.riverbench.ci_worker
 package util.doc
 
-import io.github.riverbench.ci_worker.util.RdfUtil
+import util.RdfUtil
 
 import scala.collection.mutable
 

--- a/src/main/scala/util/doc/DocValue.scala
+++ b/src/main/scala/util/doc/DocValue.scala
@@ -7,9 +7,7 @@ import org.apache.jena.datatypes.xsd.XSDDatatype.*
 import org.apache.jena.datatypes.xsd.impl.XSDBaseNumericType
 import org.apache.jena.rdf.model
 import org.apache.jena.rdf.model.Model
-import org.apache.jena.vocabulary.{RDF, RDFS, SKOS}
-
-import scala.jdk.CollectionConverters.*
+import org.apache.jena.vocabulary.{RDFS, SKOS}
 
 object DocValue:
   import MarkdownUtil.indent

--- a/src/main/scala/util/io/DigestCalculator.scala
+++ b/src/main/scala/util/io/DigestCalculator.scala
@@ -19,11 +19,11 @@
 package io.github.riverbench.ci_worker
 package util.io
 
-import akka.stream.*
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
-import akka.stream.stage.*
-import akka.util.ByteString
-import akka.{Done, NotUsed}
+import org.apache.pekko.stream.*
+import org.apache.pekko.stream.scaladsl.{Flow, Keep, Sink, Source}
+import org.apache.pekko.stream.stage.*
+import org.apache.pekko.util.ByteString
+import org.apache.pekko.{Done, NotUsed}
 
 import scala.concurrent.Future
 import scala.util.{Success, Try}
@@ -41,7 +41,7 @@ object DigAlgorithm {
 }
 
 /**
- * The DigestCalculator transforms/digests a stream of akka.util.ByteString to a
+ * The DigestCalculator transforms/digests a stream of org.apache.pekko.util.ByteString to a
  * DigestResult according to a given Algorithm
  */
 object DigestCalculator {
@@ -53,7 +53,7 @@ object DigestCalculator {
     apply(algorithm)
 
   /**
-   * Returns the String encoded as Hex representation of the digested stream of [[akka.util.ByteString]]
+   * Returns the String encoded as Hex representation of the digested stream of [[org.apache.pekko.util.ByteString]]
    */
   def hexString(algorithm: DigAlgorithm): Flow[ByteString, String, NotUsed] =
     flow(algorithm).map(res => res.messageDigest.toArray.map("%02x".format(_)).mkString).fold("")(_ + _)

--- a/src/main/scala/util/io/FileHelper.scala
+++ b/src/main/scala/util/io/FileHelper.scala
@@ -1,21 +1,20 @@
 package io.github.riverbench.ci_worker
 package util.io
 
-import akka.actor.typed.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.*
-import akka.http.scaladsl.model.headers.Location
-import akka.stream.*
-import akka.stream.alpakka.file.TarArchiveMetadata
-import akka.stream.alpakka.file.scaladsl.Archive
-import akka.stream.scaladsl.*
-import akka.util.ByteString
-import akka.{Done, NotUsed}
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream
 import org.apache.commons.io.IOUtils
+import org.apache.pekko.NotUsed
+import org.apache.pekko.actor.typed.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.*
+import org.apache.pekko.http.scaladsl.model.headers.Location
+import org.apache.pekko.stream.*
+import org.apache.pekko.stream.connectors.file.TarArchiveMetadata
+import org.apache.pekko.stream.connectors.file.scaladsl.Archive
+import org.apache.pekko.stream.scaladsl.*
+import org.apache.pekko.util.ByteString
 
-import java.io.BufferedInputStream
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 import java.time.Instant
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,8 +38,8 @@ object FileHelper:
         case r => Future { r }
       }
 
-    // Unfortunately, Alpakka untar stage is glitchy with large archives, so we have to
-    // used the non-reactive Apache Commons implementation instead.
+    // Unfortunately, Pekko untar stage is glitchy with large archives, so we have to
+    // use the non-reactive Apache Commons implementation instead.
     val tarIs = Source.futureSource(response.map(r => r.entity.dataBytes))
       .via(Compression.gunzip())
       .toMat(StreamConverters.asInputStream())(Keep.right)

--- a/src/main/scala/util/io/SaveResult.scala
+++ b/src/main/scala/util/io/SaveResult.scala
@@ -1,7 +1,7 @@
 package io.github.riverbench.ci_worker
 package util.io
 
-import akka.stream.IOResult
+import org.apache.pekko.stream.IOResult
 import util.{MetadataInfo, RdfUtil}
 
 import org.apache.jena.datatypes.xsd.XSDDatatype.*


### PR DESCRIPTION
Resolves: https://github.com/RiverBench/RiverBench/issues/46

This removes any Scala 2 dependencies (yay). Also bumped the RDF4J dependency and cleaned up the imports.
